### PR TITLE
Update zenoh-bridge.yaml

### DIFF
--- a/zenoh-bridge.yaml
+++ b/zenoh-bridge.yaml
@@ -1,6 +1,6 @@
 install: |
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
-  git clone --depth 1 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
+  git clone --depth 1 -b 1.2.1 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
   cd zenoh-plugin-ros2dds
   
   bash -c "source '$HOME/.cargo/env'; cargo build --release -p zenoh-bridge-ros2dds"
@@ -8,7 +8,7 @@ install: |
   rm -rf zenoh-plugin-ros2dds $HOME/.cargo
 package: zenoh-bridge-ros2dds
 maintainer: "Marc Hanheide <marc@hanheide.net>"
-version: 0.2.5
+version: 1.2.1
 dependencies:
   - build-essential
   - cmake

--- a/zenoh-bridge.yaml
+++ b/zenoh-bridge.yaml
@@ -1,5 +1,8 @@
-install: |
+preinstall: |
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
+install: |
+  mkdir -p /tmp/zenoh-build
+  cd /tmp/zenoh-build
   git clone --depth 1 -b 1.2.1 https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds.git
   cd zenoh-plugin-ros2dds
   


### PR DESCRIPTION
This pull request includes updates to the `zenoh-bridge.yaml` file to improve the build process and update dependencies.

Build process improvements:

* Changed the `git clone` command to checkout the specific branch `1.2.1` for the `zenoh-plugin-ros2dds` repository.

Dependency updates:

* Updated the version of `zenoh-bridge-ros2dds` from `0.2.5` to `1.2.1`.